### PR TITLE
Make initial cleanse optional

### DIFF
--- a/animo.js
+++ b/animo.js
@@ -15,7 +15,8 @@
     	animation: null,
     	iterate: 1,
     	timing: "linear",
-      keep: false
+      	keep: false,
+      	cleanse: true
     };
 
     // Browser prefixes for CSS
@@ -100,8 +101,10 @@
       } else {
 	      $me.queue.push($me.options.animation);
 	    }
-
-	    $me.cleanse();
+	    
+	    if ( $me.options.cleanse ) {
+	    	$me.cleanse();
+	    }
 
 	    $me.animate(callback);
       


### PR DESCRIPTION
This in combination with Fotorama was causing bugs for me in Chrome for some reason. I still can't figure out why removing transition & transform by cleansing them even  60 seconds before initializing Fotorama caused bugs, but it did. This is probably the weirdest bug that I've ever encountered. 

In any case - an optional initial cleanse doesn't hurt. Maybe someone has set up their initial transforms & transitions for some reason, or encounters a weird chrome bug like I did.
