### PR TITLE
Limit scope of webkit text aliasing fix

### DIFF
--- a/animate+animo.css
+++ b/animate+animo.css
@@ -12,7 +12,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-body, .animated, * { /* Addresses a small issue in webkit: http://bit.ly/NEdoDq */
+.animated { /* Addresses a small issue in webkit: http://bit.ly/NEdoDq */
 	backface-visibility: hidden;
 	-o-backface-visibility: hidden;
 	-moz-backface-visibility: hidden;


### PR DESCRIPTION
Limited the scope of the webkit text aliasing fix, which would interact badly with some flash players when the library was loaded on the same page, causing them to go invisible.
